### PR TITLE
Adds a new device: SHT31 for Adafruit Sensirion SHT31-D temp sensor

### DIFF
--- a/commanduino/commanddevices/__init__.py
+++ b/commanduino/commanddevices/__init__.py
@@ -37,9 +37,13 @@ add_to_bonjour_register('LINEARACCELSTEPPER', CommandLinearAccelStepper)
 from .commandaccelstepper import CommandAccelStepper
 add_to_bonjour_register('ACCELSTEPPER', CommandAccelStepper)
 
-# servo
+# Temperature sensors SHT1X
 from .commandsht1x import CommandSHT1X
 add_to_bonjour_register('SHT1X', CommandSHT1X)
+
+# Temperature sensors SHT31
+from .commandsht31 import CommandSHT31
+add_to_bonjour_register('SHT31', CommandSHT31)
 
 # Dallas temperature sensors
 from .commanddallas import CommandDallas

--- a/commanduino/commanddevices/commandsht31.py
+++ b/commanduino/commanddevices/commandsht31.py
@@ -1,0 +1,49 @@
+from .commanddevice import CommandDevice
+
+import logging
+module_logger = logging.getLogger(__name__)
+
+# bonjour info
+BONJOUR_ID = 'SHT31'
+CLASS_NAME = 'CommandSHT31'
+
+# incoming
+CMD_ANSWER_CELSIUS = 'C'
+CMD_ANSWER_HUMIDITY = 'H'
+
+# outgoing
+CMD_REQUEST_CELSIUS = 'RC'
+CMD_REQUEST_HUMIDITY = 'RH'
+
+
+class CommandSHT31(CommandDevice):
+
+    def __init__(self):
+        CommandDevice.__init__(self)
+        self.register_all_requests()
+
+    ##
+    def register_all_requests(self):
+        self.register_request(
+            CMD_REQUEST_CELSIUS,
+            CMD_ANSWER_CELSIUS,
+            'celsius',
+            self.handle_celsius_command)
+
+        self.register_request(
+            CMD_REQUEST_HUMIDITY,
+            CMD_ANSWER_HUMIDITY,
+            'humidity',
+            self.handle_humidity_command)
+
+    def handle_celsius_command(self, *arg):
+        print(str(arg))
+        if arg[0]:
+            self.celsius = float(arg[0])
+            self.celsius_lock.ensure_released()
+
+    def handle_humidity_command(self, *arg):
+        print(str(arg))
+        if arg[0]:
+            self.humidity = float(arg[0])
+            self.humidity_lock.ensure_released()

--- a/examples/commanddevices/commandsht31/demo.json
+++ b/examples/commanddevices/commandsht31/demo.json
@@ -1,0 +1,21 @@
+{
+  "ios" : [
+    {
+      "port": "/dev/tty.usbmodem1411"
+    },
+    {
+      "port": "/dev/ttyACM0"
+    },
+    {
+      "port": "/dev/ttyACM1"
+    },
+    {
+      "port": "/dev/ttyACM2"
+    }
+  ],
+  "devices": {
+    "sht31": {
+      "command_id": "SHT31"
+    }
+  }
+}

--- a/examples/commanddevices/commandsht31/demo.py
+++ b/examples/commanddevices/commandsht31/demo.py
@@ -1,0 +1,15 @@
+import time
+import logging
+from commanduino import CommandManager
+
+logging.basicConfig(level=logging.INFO)
+
+cmdMng = CommandManager.from_configfile('./demo.json')
+
+for i in range(10):
+    C = cmdMng.sht31.get_celsius()
+    H = cmdMng.sht31.get_humidity()
+    print('###')
+    print('Temperature = {} C'.format(C))
+    print('Humidity = {}%'.format(H))
+    time.sleep(1)


### PR DESCRIPTION
Basically the same of SHT1X, but uses Adafruit library as base instead.
Connection via i2c no need to specify pins, e.g.:

// Temperature sensor
CommandSHT31 cmdSHT31;

void setup() {
    cmdSHT31.registerToCommandManager(mgr, "SHT31");
}