### PR TITLE
Introduces VirtualCommandManager for use in simulations

### DIFF
--- a/commanduino/__init__.py
+++ b/commanduino/__init__.py
@@ -16,3 +16,4 @@ from .commandhandler import CommandHandler
 from .commandhandler import SerialCommandHandler
 
 from .commandmanager import CommandManager
+from .commandmanager import VirtualCommandManager

--- a/commanduino/commanddevices/__init__.py
+++ b/commanduino/commanddevices/__init__.py
@@ -49,6 +49,9 @@ add_to_bonjour_register('SHT31', CommandSHT31)
 from .commanddallas import CommandDallas
 add_to_bonjour_register('DALLAS', CommandDallas)
 
+# virtual
+from .commandvirtual import CommandVirtual
+
 # automated way, seems to only works in develop mode :(
 
 # import os

--- a/commanduino/commanddevices/commandvirtual.py
+++ b/commanduino/commanddevices/commandvirtual.py
@@ -1,0 +1,89 @@
+from .commanddevice import CommandDevice
+
+import logging
+
+module_logger = logging.getLogger(__name__)
+
+
+class CommandVirtual(CommandDevice):
+    """
+    Virtual omnipotent device.
+    """
+
+    def __init__(self):
+        CommandDevice.__init__(self)
+
+    def disable_acceleration(self):
+        pass
+
+    def disable_revert_switch(self):
+        pass
+
+    def enable_acceleration(self):
+        pass
+
+    def enable_revert_switch(self):
+        pass
+
+    def get_celsius(self):
+        pass
+
+    def get_current_position(self):
+        return 0
+
+    def get_humidity(self):
+        pass
+
+    def get_state(self):
+        pass
+
+    def high(self):
+        pass
+
+    def home(self, wait=True):
+        pass
+
+    def is_moving(self):
+        return False
+
+    def low(self):
+        pass
+
+    def move(self, position=[], wait=True):
+        pass
+
+    def move_to(self, position=[], wait=True):
+        pass
+
+    def set_acceleration(self, steps_per_second_per_second):
+        pass
+
+    def set_angle(self, angle):
+        pass
+
+    def set_homing_speed(self, steps_per_second):
+        pass
+
+    def set_level(self, level):
+        pass
+
+    def set_limit(self, minimum=0, maximum=180):
+        pass
+
+    def set_max_speed(self, steps_per_second):
+        pass
+
+    def set_pwm_value(self, value):
+        pass
+
+    def set_running_speed(self, steps_per_second):
+        pass
+
+    def set_speed(self, steps_per_second):
+        pass
+
+    def stop(self):
+        pass
+
+    def wait_until_idle(self):
+        pass

--- a/commanduino/commandmanager.py
+++ b/commanduino/commandmanager.py
@@ -266,6 +266,45 @@ class CommandManager(object):
             self.logger.warning('Received unknown command "{}"'.format(cmd))
 
 
+class VirtualCommandManager(CommandManager):
+    def __init__(self, serialcommand_configs, devices_dict, init_timeout=DEFAULT_INIT_TIMEOUT, init_n_repeats=DEFAULT_INIT_N_REPEATS):
+        self.logger = create_logger(self.__class__.__name__)
+
+        self.init_n_repeats = init_n_repeats
+        self.init_lock = Lock(init_timeout)
+
+        self.serialcommandhandlers = []
+        self.initialised = True
+        self.register_all_devices(devices_dict)
+        self.set_devices_as_attributes()
+        self.initialised = True
+
+    def register_device(self, device_name, device_info):
+        """
+        Registers an individual Arduino device.
+
+        Args:
+            device_name (str): Name of the device.
+
+            device_info (Dict): Dictionary containing the device information.
+
+        Raises:
+            DeviceRegisterError: Device is not in the device register.
+
+            BonjourError: Device has not been found.
+
+        """
+        command_id = device_info['command_id']
+        if 'config' in device_info:
+            device_config = device_info['config']
+        else:
+            device_config = {}
+
+        from commanduino.commanddevices import CommandVirtual
+
+        self.devices[device_name] = CommandVirtual()
+
+
 class InitError(Exception):
     """
     Exception for when the manager fails to initialise.


### PR DESCRIPTION
VirtualCommandManager has to be called instead of CommandManager for virtual experiments.
This allows to test code that depends on commanduino without actually connecting any device to the PC (e.g. to test a robot platform on office PC).