### PR TITLE
Ability to add/remove command handlers on the fly.

### DIFF
--- a/commanduino/commandmanager.py
+++ b/commanduino/commandmanager.py
@@ -46,7 +46,7 @@ class CommandManager(object):
 
         devices_dict (Dict): Dictionary containing the list of devices.
 
-        init_timeout (int): Initialisation timeout, default se tto DEFAULT_INIT_TIMEOUT (1).
+        init_timeout (int): Initialisation timeout, default set to DEFAULT_INIT_TIMEOUT (1).
 
         init_n_repeats (int): Number of times to attempt initialisation, default set to DEFAULT_INIT_N_REPEATS (5).
 
@@ -65,40 +65,91 @@ class CommandManager(object):
         self.init_lock = Lock(init_timeout)
 
         self.commandhandlers = []
-        for _, config in enumerate(command_configs):
-            if "type" in config:
-                handler_type = config["type"]
-                config.pop("type")
-            else:
-                self.logger.warning("No command handler type provided in configuration. Falling back to serial.")
-                handler_type = "serial"
-            device_name = config.get("address", "") + ":" + config.get("port", "")
-            try:
-                if handler_type == "serial":
-                    handler = SerialCommandHandler.from_config(config)
-                    self.logger.info("Created serial-based command handler for %s.", device_name)
-                elif handler_type == "tcpip":
-                    handler = TCPIPCommandHandler.from_config(config)
-                    self.logger.info("Created socket-based command handler for %s.", device_name)
-                handler.add_default_handler(self.unrecognized)
-                handler.start()
-            except (SerialException, OSError, TypeError):
-                if 'required' in config and config['required'] is True:
-                    self.logger.error("I/O device %s (type %s) was not found and it is required! Aborting...", device_name, handler_type)
-                    sys.exit(1)
-                else:
-                    self.logger.warning("I/O device %s (type %s) was not found", device_name, handler_type)
-                    continue
-            try:
-                elapsed = self.wait_device_for_init(handler)
-                self.logger.info('Found CommandManager at %s, init time was %s seconds', device_name,  round(elapsed, 3))
-            except InitError:
-                self.logger.warning('CommandManager at %s has not initialized', device_name)
-            self.commandhandlers.append(handler)
-
+        for config_entry in command_configs:
+            # Create handler from config & initialize device
+            self.add_command_handler(config_entry)
         self.register_all_devices(devices_dict)
         self.set_devices_as_attributes()
         self.initialised = True
+
+    def add_command_handler(self, handler_config):
+        """Creates command handler from the configuration dictionary, tests connection
+        and appends instance to self.commandhandlers
+
+        Args:
+            handler_config (Dict): Handler configuration dictionary.
+        """
+        handler = None
+        # Check if type is present, if not - log and fall back to serial
+        # for backwards compatibility reasons.
+        if "type" in handler_config:
+            handler_type = handler_config["type"]
+            # Remove connection type from config dict copy - not needed any more
+            # Copying is needed not to mutate original dict - might be re-used
+            # by upper-level code for object re-creation.
+            handler_config = handler_config.copy()
+            handler_config.pop("type")
+        else:
+            self.logger.warning("No command handler type provided in configuration. Falling back to serial.")
+            handler_type = "serial"
+        # Get full name - for use in logging
+        device_name = handler_config.get("address", "") + ":" + handler_config.get("port", "")
+        try:
+            if handler_type == "serial":
+                handler = SerialCommandHandler.from_config(handler_config)
+                self.logger.info("Created serial-based command handler for %s.", device_name)
+            elif handler_type == "tcpip":
+                handler = TCPIPCommandHandler.from_config(handler_config)
+                self.logger.info("Created socket-based command handler for %s.", device_name)
+            handler.add_default_handler(self.unrecognized)
+            handler.start()
+        except (SerialException, OSError, TypeError) as e:
+            if 'required' in handler_config and handler_config['required'] is True:
+                self.logger.error("I/O device %s (type %s) was not found and it is required! Aborting...", device_name, handler_type)
+                self.logger.error("Additional error message: %s", e)
+                sys.exit(1)
+            else:
+                self.logger.warning("I/O device %s (type %s) was not found", device_name, handler_type)
+                self.logger.warning("Additional error message: %s", e)
+
+        # Initialize device
+        if handler is not None:
+            try:
+                elapsed = self.wait_device_for_init(handler)
+                self.logger.info('Found Arduino CommandManager at %s, init time was %s seconds', device_name, round(elapsed, 3))
+            except InitError:
+                self.logger.warning('Arduino CommandManager at %s has not initialized', device_name)
+                return
+            # Update handlers list
+            self.commandhandlers.append(handler)
+
+    def remove_command_handler(self, handler_to_remove):
+        """
+        Deletes the command handler object & removes a reference to it from
+        class dictionary. Then deletes the devices bound to the handler being deleted.
+
+        The method to detect which devices depend on the handler being deleted
+        may seem wanky because it is.
+        However, it is the only possible method as every device internal
+        CommanHandler doesn't hold a reference to an actual command handler.
+        The only thing having this reference is the device's write() function
+        which gets updated on create_and_setup_device()
+        """
+        if handler_to_remove not in self.commandhandlers:
+            self.logger.warning("Command handler %s not found!", handler_to_remove)
+            return
+        self.logger.info("Removing devices...")
+        # Find the dependent devices to remove
+        for name, dev in self.devices.copy().items():
+            if handler_to_remove is dev.write.__self__:
+                self.logger.info("Removing dependent device %s", name)
+                # Remove device attribute
+                delattr(self, name)
+                # Remove reference from device list
+                self.devices.pop(name)
+        # Remove handler
+        self.logger.info("Removing command handler...")
+        self.commandhandlers.remove(handler_to_remove)
 
     def set_devices_as_attributes(self):
         """
@@ -106,7 +157,7 @@ class CommandManager(object):
         """
         for device_name, device in list(self.devices.items()):
             if hasattr(self, device_name):
-                self.logger.warning("Device named {device_name} is already a reserved attribute, please change name or do not use this pump in attribute mode, rather use pumps[{device_name}]".format(device_name=device_name))
+                self.logger.warning("Device named {device_name} is already a reserved attribute, please change name or do not use this device in attribute mode, rather use devices[{device_name}]".format(device_name=device_name))
             else:
                 setattr(self, device_name, device)
 

--- a/commanduino/commandmanager.py
+++ b/commanduino/commandmanager.py
@@ -68,6 +68,8 @@ class CommandManager(object):
         for config_entry in command_configs:
             # Create handler from config & initialize device
             self.add_command_handler(config_entry)
+
+        self.devices = {}
         self.register_all_devices(devices_dict)
         self.set_devices_as_attributes()
         self.initialised = True
@@ -247,7 +249,6 @@ class CommandManager(object):
             devices_dict (Dict): Dictionary containing all devices.
 
         """
-        self.devices = {}
         for device_name, device_info in devices_dict.items():
             self.register_device(device_name, device_info)
 

--- a/commanduino/commandmanager.py
+++ b/commanduino/commandmanager.py
@@ -145,10 +145,7 @@ class CommandManager(object):
         for name, dev in self.devices.copy().items():
             if handler_to_remove is dev.write.__self__:
                 self.logger.info("Removing dependent device %s", name)
-                # Remove device attribute
-                delattr(self, name)
-                # Remove reference from device list
-                self.devices.pop(name)
+                self.unregister_device(name)
         # Remove handler
         self.logger.info("Removing command handler...")
         self.commandhandlers.remove(handler_to_remove)
@@ -297,6 +294,15 @@ class CommandManager(object):
 
         except BonjourError:
             self.logger.warning('Device "{name}" with id "{id}" has not been found'.format(name=device_name, id=command_id))
+
+    def unregister_device(self, device_name):
+        """
+        Removes device attribute & reference from devices dictionary
+        """
+        # Remove device attribute from self
+        delattr(self, device_name)
+        # Remove reference from device list
+        self.devices.pop(device_name)
 
     @classmethod
     def from_config(cls, config):

--- a/examples/commandmanager/two_boards/two_boards.py
+++ b/examples/commandmanager/two_boards/two_boards.py
@@ -12,6 +12,6 @@ s1 = cmdMng.devices['servo1']
 s2 = cmdMng.devices['servo2']
 m1 = cmdMng.devices['stepper1']
 
-from commandruino.devices.axis import Axis
+from commanduino.devices.axis import Axis
 
 a = Axis(m1, 0.1)


### PR DESCRIPTION
This PR provides a functionality to add/remove devices and command handlers on the fly without recreating a CommandManager object.

The add-on-the-fly functionality is needed for the future Chemputer code where a single CommandManager instance might server multiple virtual devices represented by separate graph nodes (e.g. pneumatic manifold and a conductivity sensor).

The remove functionality does not yet seem to be needed, however it would be strange to implement addition only.

This code has been tested on two Arduino boards, one connected over Ethernet, the other one over serial as following:
1. First, an instance of CommandManager having only one board (Eth) defined has been created from JSON.
2. Then, the following code was invoked:
```python
manager.add_command_handler({"type":"serial", "port":"COM9"})
manager.register_all_devices({"LED":{"command_id": "LEDW"}})
manager.set_devices_as_attributes()
```
3. Then manager was inspected to ensure it has LED set both as an attribute and in devices dictionary.
4. The functionality was tested and the command handler was removed:
```python
manager.LED.set_level(1)
manager.LED.set_level(1)
manager.remove_command_handler(s.manager.commandhandlers[1])
```
5. Then the manager was inspected again to ensure LED control object has been removed.

Everything seems to work fine so far however more testing would be great before merging.
