### PR TITLE
Removes custom _logger.py

### DIFF
--- a/commanduino/__init__.py
+++ b/commanduino/__init__.py
@@ -5,10 +5,9 @@ Custom library designed to interface with Arduino hardware, allowing for control
 
 """
 from ._version import __version__
-from ._logger import __logger_root_name__
 
 import logging
-logging.getLogger(__logger_root_name__).addHandler(logging.NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 from .lock import Lock
 

--- a/commanduino/_logger.py
+++ b/commanduino/_logger.py
@@ -1,7 +1,0 @@
-import logging
-
-__logger_root_name__ = 'commanduino'
-
-
-def create_logger(name):
-    return logging.getLogger(__logger_root_name__ + '.' + name)

--- a/commanduino/commanddevices/commanddevice.py
+++ b/commanduino/commanddevices/commanddevice.py
@@ -10,7 +10,7 @@
 from ..commandhandler import CommandHandler
 from ..lock import Lock
 
-from .._logger import create_logger
+import logging
 
 # Default timeout value
 DEFAULT_TIMEOUT = 1
@@ -63,7 +63,7 @@ class CommandDevice(object):
     Base class to represent the different Arduino devices.
     """
     def __init__(self):
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         self.cmdHdl = CommandHandler()
         self.cmdHdl.add_default_handler(self.unrecognized)

--- a/commanduino/commandhandler.py
+++ b/commanduino/commandhandler.py
@@ -11,8 +11,7 @@ import time
 import serial
 import socket
 import threading
-
-from ._logger import create_logger
+import logging
 
 # Default delimiter to separate commands
 DEFAULT_DELIM = ','
@@ -60,7 +59,7 @@ class CommandHandler(object):
         return cls(**config)
 
     def __init__(self, delim=DEFAULT_DELIM, term=DEFAULT_TERM, cmd_decimal=DEFAULT_CMD_DECIMAL, **kwargs):
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         # Something descriptive to reference the handler in logs.
         self.name = self.__class__.__name__
@@ -304,7 +303,7 @@ class SerialCommandHandler(threading.Thread, CommandHandler):
         self.daemon = True
         self.interrupted = threading.Lock()
 
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         CommandHandler.__init__(self, delim, term, cmd_decimal)
         self.name = port
@@ -442,7 +441,7 @@ class TCPIPCommandHandler(threading.Thread, CommandHandler):
         self.interrupted = threading.Event()
         self.interrupted.clear()
 
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         CommandHandler.__init__(self, delim, term, cmd_decimal)
 

--- a/commanduino/commandmanager.py
+++ b/commanduino/commandmanager.py
@@ -14,10 +14,10 @@ from .commanddevices.register import DEFAULT_REGISTER
 from .commanddevices.register import DeviceRegisterError
 
 from .lock import Lock
-from ._logger import create_logger
 
 import time
 import sys
+import logging
 from serial import SerialException
 
 # Default initialisation timeout
@@ -58,7 +58,7 @@ class CommandManager(object):
         InitError: CommandManager on port was not initialised.
     """
     def __init__(self, command_configs, devices_dict, init_timeout=DEFAULT_INIT_TIMEOUT, init_n_repeats=DEFAULT_INIT_N_REPEATS):
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         self.initialised = False
         self.init_n_repeats = init_n_repeats
@@ -352,7 +352,7 @@ class CommandManager(object):
 
 class VirtualCommandManager(CommandManager):
     def __init__(self, command_configs, devices_dict, init_timeout=DEFAULT_INIT_TIMEOUT, init_n_repeats=DEFAULT_INIT_N_REPEATS):
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         self.init_n_repeats = init_n_repeats
         self.init_lock = Lock(init_timeout)
@@ -413,7 +413,7 @@ class CommandBonjour(object):
 
     """
     def __init__(self, commandhandlers, timeout=DEFAULT_BONJOUR_TIMEOUT):
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 
         self.commandhandlers = commandhandlers
         self.lock = Lock(timeout)

--- a/commanduino/devices/axis.py
+++ b/commanduino/devices/axis.py
@@ -8,7 +8,7 @@
 
 """
 
-from .._logger import create_logger
+import logging
 
 
 class Axis(object):
@@ -30,7 +30,7 @@ class Axis(object):
 
     def __init__(self, linear_actuator, unit_per_step=1, min_position=0,
                  max_position=float('inf')):
-        self.logger = create_logger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
         self.linear_actuator = linear_actuator
         self.unit_per_step = float(unit_per_step)
         self.min_position = float(min_position)


### PR DESCRIPTION
Given that `__logger_root_name__ == __name__` there's no need for create_logger(), assuming the logger base name would always be "commanduino".