### PR TITLE
Refactor handlers exceptions

### DIFF
--- a/commanduino/commandmanager.py
+++ b/commanduino/commandmanager.py
@@ -12,15 +12,20 @@ from .commandhandler import TCPIPCommandHandler
 from .commanddevices.register import create_and_setup_device
 from .commanddevices.register import DEFAULT_REGISTER
 
-from .exceptions import CMManagerConfigurationError, CMHandlerConfigurationError, CMHandlerDiscoveryTimeout,\
-    CMDeviceConfigurationError, CMBonjourTimeout, CMDeviceDiscoveryTimeout, CMDeviceRegisterError
+from .exceptions import (CMManagerConfigurationError,
+                        CMHandlerConfigurationError,
+                        CMHandlerDiscoveryTimeout,
+                        CMDeviceConfigurationError,
+                        CMBonjourTimeout,
+                        CMDeviceDiscoveryTimeout,
+                        CMDeviceRegisterError,
+                        CMCommunicationError)
 
 from .lock import Lock
 
 import time
 import json
 import logging
-from serial import SerialException
 
 # Default initialisation timeout
 DEFAULT_INIT_TIMEOUT = 1
@@ -48,13 +53,6 @@ class CommandManager(object):
         init_timeout (int): Initialisation timeout, default set to DEFAULT_INIT_TIMEOUT (1).
 
         init_n_repeats (int): Number of times to attempt initialisation, default set to DEFAULT_INIT_N_REPEATS (5).
-
-    Raises:
-        OSError: Port was not found.
-
-        SerialException: Port was not found.
-
-        InitError: CommandManager on port was not initialised.
     """
     def __init__(self, command_configs, devices_dict, init_timeout=DEFAULT_INIT_TIMEOUT, init_n_repeats=DEFAULT_INIT_N_REPEATS, simulation=False):
         self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
@@ -111,7 +109,7 @@ class CommandManager(object):
             elif handler_type == "tcpip":
                 handler = TCPIPCommandHandler.from_config(handler_config)
                 self.logger.info("Created socket-based command handler for %s.", device_name)
-        except (SerialException, OSError, TypeError, ValueError) as e:
+        except CMHandlerConfigurationError as e:
             if required:
                 raise CMHandlerConfigurationError(f"Error initializing device {device_name}: {e}") from None
             else:
@@ -225,7 +223,10 @@ class CommandManager(object):
         self.logger.debug('Waiting for device at %s to init...', handler.name)
 
         handler.add_command(COMMAND_INIT, self.handle_init)
-        is_init, elapsed = self.request_and_wait_for_init(handler)
+        try:
+            is_init, elapsed = self.request_and_wait_for_init(handler)
+        except CMCommunicationError:
+            raise CMHandlerDiscoveryTimeout(handler.name)
         handler.remove_command(COMMAND_INIT, self.handle_init)
         if is_init:
             return elapsed

--- a/commanduino/exceptions.py
+++ b/commanduino/exceptions.py
@@ -9,6 +9,23 @@ class CMError(Exception):
     """ Base catch-all"""
 
 
+class CMDeviceRegisterError(CMError):
+    """
+    When the Bonjour ID is not in the register of the device.
+    """
+    def __init__(self, bonjour_id):
+        self.bonjour_id = bonjour_id
+
+    def __str__(self):
+        return '{self.bonjour_id} is not in the register of device'.format(self=self)
+
+
+class CMCommunicationError(CMError):
+    """
+    Can't communicate to device - broken connection or device doesn't reply
+    """
+
+
 # CONFIGURATION ERRORS
 class CMConfigurationError(CMError):
     """ Base error for wrong configuration """
@@ -76,14 +93,3 @@ class CMDeviceReplyTimeout(CMTimeout):
 
     def __str__(self):
         return f"{self.device_name} did not respond to {self.command_name} within {self.elapsed:.3} s"
-
-
-class CMDeviceRegisterError(CMError):
-    """
-    When the Bonjour ID is not in the register of the device.
-    """
-    def __init__(self, bonjour_id):
-        self.bonjour_id = bonjour_id
-
-    def __str__(self):
-        return '{self.bonjour_id} is not in the register of device'.format(self=self)


### PR DESCRIPTION
Minor change - command handler specific exceptions have bуут moved inside respective handler classes.
A new exception class - CMCommunicationError - has been added; all read/write methods in handlers now can would throw this exception instead of a connection-specific one.